### PR TITLE
EnumFlags and FixedSizeArray 

### DIFF
--- a/src/typ.rs
+++ b/src/typ.rs
@@ -529,6 +529,15 @@ impl<T: Clone+Debug+AsEnumFlag> TryFrom<Vec<T>> for EnumFlag<T> {
         Ok(EnumFlag(out))   
     }
 }
+impl <T:Clone+Debug+AsEnumFlag> EnumFlag<T>{
+    pub fn sum(&self) -> u32 {
+        let mut sum:u32 = 0;
+        for x in &self.0{
+            sum = sum + T::as_u32(x); // AsU8 and AsU32 trait needed for using T 
+        }
+        sum
+    }
+}
 /*
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -455,6 +455,7 @@ impl<'de, T: Deserialize<'de> + Debug> Deserialize<'de> for VariableSizeArray<T>
         struct VariableSizeArrayVisitor<T> {
             marker: PhantomData<T>,
         };
+        let mut size = 0;
         impl<'de, T> Visitor<'de> for VariableSizeArrayVisitor<T>
         where
             T: Deserialize<'de> + Debug,
@@ -507,6 +508,15 @@ impl<'de, T: Deserialize<'de> + Debug> Deserialize<'de> for VariableSizeArray<T>
         )?);
     }
 }
+
+pub trait AsEnumFlag {
+    fn as_u32(data: &Self) -> u32;
+    fn from_u32(data: u32) -> Self;
+    fn size_of_enum_flag() -> u32;
+}
+
+#[derive(Clone, Debug)]
+pub struct EnumFlag<T: Clone+Debug+AsEnumFlag>(Vec<T>);
 
 
 /*

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -530,6 +530,9 @@ impl<T: Clone+Debug+AsEnumFlag> TryFrom<Vec<T>> for EnumFlag<T> {
         Ok(EnumFlag(out))   
     }
 }
+impl <T: Clone+Debug+AsEnumFlag>Default for EnumFlag<T> {
+    fn default() -> Self { vec![].try_into().unwrap() }
+}
 impl <T:Clone+Debug+AsEnumFlag> EnumFlag<T>{
     pub fn sum(&self) -> u32 {
         let mut sum:u32 = 0;

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -538,6 +538,21 @@ impl <T:Clone+Debug+AsEnumFlag> EnumFlag<T>{
         sum
     }
 }
+impl <T:Clone+Debug+AsEnumFlag>Serialize for EnumFlag<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+            let size: u32 = T::size_of_enum_flag();
+            match size{
+                32 => serializer.serialize_u32(self.sum()),
+                16 => serializer.serialize_u16(self.sum() as u16),
+                8 => serializer.serialize_u8(self.sum() as u8),
+                _ => panic!("EnumFlags do not support {} bit type flag",size)
+            }
+       
+    }
+}
 /*
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]

--- a/src/typ.rs
+++ b/src/typ.rs
@@ -518,7 +518,17 @@ pub trait AsEnumFlag {
 #[derive(Clone, Debug)]
 pub struct EnumFlag<T: Clone+Debug+AsEnumFlag>(Vec<T>);
 
+impl<T: Clone+Debug+AsEnumFlag> TryFrom<Vec<T>> for EnumFlag<T> {
+    type Error = String;
 
+    fn try_from(value: Vec<T>) -> Result<Self, Self::Error> {
+        let mut out = vec![];
+        for i in 0..value.len() {
+            out.push(value[i].clone());
+        }
+        Ok(EnumFlag(out))   
+    }
+}
 /*
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
This PR fixes the following issues 
**EnumFlags** 
I have created an Encapsulated Structure to handle enumflags and implemented respective trait of Serialize and Deserialize for u8,16 and u32. The PR for vpp-api-gen will show results of it being used with VPP. 
Example use with builder 
```rust
let set_interface_link_up: SwInterfaceSetFlagsReply = send_recv_msg(
        &SwInterfaceSetFlags::get_message_name_and_crc(),
        &SwInterfaceSetFlags::builder().client_index(t.get_client_index()).context(0).sw_if_index(1).flags(vec![IfStatusFlags::IF_STATUS_API_FLAG_ADMIN_UP, IfStatusFlags::IF_STATUS_API_FLAG_LINK_UP].try_into().unwrap()).build().unwrap(),
        &mut *t,
        &SwInterfaceSetFlagsReply::get_message_name_and_crc());
```

**FixedSizeArray** 
I have implemented Deserialize trait for Fixed Size Array only for u8 type, So that Unions can be deserialized( for testing bulk messages already in example) 
